### PR TITLE
Gas-Efficient Clarity Smart Contract

### DIFF
--- a/gingo_contract/Clarinet.toml
+++ b/gingo_contract/Clarinet.toml
@@ -30,6 +30,11 @@ path = 'contracts/data_storage.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.gas_efficient_wallet]
+path = 'contracts/gas_efficient_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.res]
 path = 'contracts/res.clar'
 clarity_version = 2

--- a/gingo_contract/contracts/gas_efficient_wallet.clar
+++ b/gingo_contract/contracts/gas_efficient_wallet.clar
@@ -213,3 +213,17 @@
 )
 
 
+;; Optimized multi-signature verification (if needed)
+;; Uses fold to minimize loop overhead
+(define-private (verify-signatures (message (buff 32)) (signatures (list 5 (buff 65))) (signers (list 5 principal)))
+  ;; Implementation would verify signatures efficiently
+  ;; This is a placeholder for multi-sig functionality
+  true
+)
+
+;; Gas estimation helper (read-only)
+(define-read-only (estimate-transfer-cost (amount uint))
+  ;; Return estimated gas cost for transfer
+  ;; Based on current network conditions
+  (ok u1000) ;; Placeholder value
+)

--- a/gingo_contract/contracts/gas_efficient_wallet.clar
+++ b/gingo_contract/contracts/gas_efficient_wallet.clar
@@ -1,0 +1,215 @@
+;; Gas-Efficient Wallet Contract
+;; Minimizes storage writes and optimizes balance operations
+
+;; Error constants
+(define-constant ERR-UNAUTHORIZED (err u100))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u101))
+(define-constant ERR-INVALID-AMOUNT (err u102))
+(define-constant ERR-TRANSFER-FAILED (err u103))
+
+;; Contract owner
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; Storage optimization: Use a single map for all user data
+;; This reduces storage reads/writes by batching related data
+(define-map wallets
+  { user: principal }
+  { 
+    balance: uint,
+    nonce: uint,  ;; For replay protection without additional storage
+    last-activity: uint  ;; Block height of last activity
+  }
+)
+
+;; Optimized balance storage - only store non-zero balances
+;; This saves gas by not storing empty wallet entries
+(define-private (get-wallet-data (user principal))
+  (default-to 
+    { balance: u0, nonce: u0, last-activity: u0 }
+    (map-get? wallets { user: user })
+  )
+)
+
+;; Gas-efficient balance check
+(define-read-only (get-balance (user principal))
+  (get balance (get-wallet-data user))
+)
+
+;; Get user nonce (for transaction ordering)
+(define-read-only (get-nonce (user principal))
+  (get nonce (get-wallet-data user))
+)
+
+;; Get last activity block height
+(define-read-only (get-last-activity (user principal))
+  (get last-activity (get-wallet-data user))
+)
+
+;; Optimized deposit function
+;; Uses STX transfer with minimal storage operations
+(define-public (deposit (amount uint))
+  (let ((sender tx-sender)
+        (current-data (get-wallet-data sender)))
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    
+    ;; Single storage write combining all updates
+    (map-set wallets
+      { user: sender }
+      {
+        balance: (+ (get balance current-data) amount),
+        nonce: (get nonce current-data),
+        last-activity: block-height
+      }
+    )
+    
+    ;; Transfer STX to contract
+    (stx-transfer? amount sender (as-contract tx-sender))
+  )
+)
+
+;; Gas-efficient withdrawal
+(define-public (withdraw (amount uint))
+  (let ((sender tx-sender)
+        (current-data (get-wallet-data sender))
+        (current-balance (get balance current-data)))
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    (asserts! (>= current-balance amount) ERR-INSUFFICIENT-BALANCE)
+    
+    (let ((new-balance (- current-balance amount)))
+      ;; Optimize storage: remove entry if balance becomes zero
+      (if (is-eq new-balance u0)
+        (map-delete wallets { user: sender })
+        (map-set wallets
+          { user: sender }
+          {
+            balance: new-balance,
+            nonce: (+ (get nonce current-data) u1),
+            last-activity: block-height
+          }
+        )
+      )
+      
+      ;; Transfer STX from contract to user
+      (as-contract (stx-transfer? amount tx-sender sender))
+    )
+  )
+)
+
+;; Batch transfer for gas efficiency
+;; Process multiple transfers in a single transaction
+(define-public (batch-transfer (recipients (list 10 { to: principal, amount: uint })))
+  (let ((sender tx-sender)
+        (current-data (get-wallet-data sender)))
+    
+    ;; Calculate total amount needed
+    (let ((total-amount (fold + (map get-transfer-amount recipients) u0))
+          (current-balance (get balance current-data)))
+      
+      (asserts! (>= current-balance total-amount) ERR-INSUFFICIENT-BALANCE)
+      
+      ;; Update sender balance once
+      (let ((new-balance (- current-balance total-amount)))
+        (if (is-eq new-balance u0)
+          (map-delete wallets { user: sender })
+          (map-set wallets
+            { user: sender }
+            {
+              balance: new-balance,
+              nonce: (+ (get nonce current-data) u1),
+              last-activity: block-height
+            }
+          )
+        )
+        
+        ;; Process all transfers
+        (ok (map process-single-transfer recipients))
+      )
+    )
+  )
+)
+
+;; Helper function for batch transfer
+(define-private (get-transfer-amount (transfer { to: principal, amount: uint }))
+  (get amount transfer)
+)
+
+;; Process individual transfer in batch
+(define-private (process-single-transfer (transfer { to: principal, amount: uint }))
+  (let ((recipient (get to transfer))
+        (amount (get amount transfer))
+        (recipient-data (get-wallet-data recipient)))
+    
+    ;; Update recipient balance
+    (map-set wallets
+      { user: recipient }
+      {
+        balance: (+ (get balance recipient-data) amount),
+        nonce: (get nonce recipient-data),
+        last-activity: block-height
+      }
+    )
+    amount
+  )
+)
+
+;; Internal transfer between wallet users (no STX movement)
+;; Most gas-efficient transfer method
+(define-public (internal-transfer (to principal) (amount uint))
+  (let ((sender tx-sender)
+        (sender-data (get-wallet-data sender))
+        (recipient-data (get-wallet-data to)))
+    
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    (asserts! (not (is-eq sender to)) ERR-INVALID-AMOUNT)
+    (asserts! (>= (get balance sender-data) amount) ERR-INSUFFICIENT-BALANCE)
+    
+    (let ((sender-new-balance (- (get balance sender-data) amount))
+          (recipient-new-balance (+ (get balance recipient-data) amount)))
+      
+      ;; Update sender
+      (if (is-eq sender-new-balance u0)
+        (map-delete wallets { user: sender })
+        (map-set wallets
+          { user: sender }
+          {
+            balance: sender-new-balance,
+            nonce: (+ (get nonce sender-data) u1),
+            last-activity: block-height
+          }
+        )
+      )
+      
+      ;; Update recipient
+      (map-set wallets
+        { user: to }
+        {
+          balance: recipient-new-balance,
+          nonce: (get nonce recipient-data),
+          last-activity: block-height
+        }
+      )
+      
+      (ok amount)
+    )
+  )
+)
+
+;; Emergency functions for contract owner
+(define-public (emergency-pause)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    ;; Emergency pause logic would go here
+    (ok true)
+  )
+)
+
+
+;; Get contract statistics (read-only, no gas cost for storage)
+(define-read-only (get-contract-stats)
+  (ok {
+    contract-balance: (stx-get-balance (as-contract tx-sender)),
+    block-height: block-height
+  })
+)
+
+

--- a/gingo_contract/tests/gas_efficient_wallet.test.ts
+++ b/gingo_contract/tests/gas_efficient_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Gas-Efficient Wallet – README

A Clarity smart contract focused on minimizing storage reads/writes while providing a simple wallet with deposits, withdrawals, internal transfers, and batched transfers. It favors single‐map storage, conditional writes, and consolidated updates to reduce execution cost.

---

## Overview

* **Contract goal:** Track STX balances for users and move value with as few storage operations as possible.
* **Core ideas:**

  * One `wallets` map for all per-user data (balance, nonce, last-activity).
  * Avoid storing zero-balance entries.
  * Combine related updates into a **single** `map-set`.
  * Support **internal transfers** (ledger updates only) and **batch transfers** (one debit, many credits).

---

## Features

* **Single-map storage layout** with `{balance, nonce, last-activity}`.
* **Optimized deposit/withdraw:** one write per action; deletes storage when balance hits zero.
* **Internal transfers:** most gas-efficient—no STX movement, only ledger updates.
* **Batch transfers:** one debit from sender, bulk credits to recipients in a single tx.
* **Read-only helpers:** balance, nonce, last activity, contract stats.
* **Owner utility:** placeholder `emergency-pause` (extend to gate state changes).
* **Pluggable multi-sig check:** placeholder `verify-signatures` for future use.
* **Gas hints:** `estimate-transfer-cost` (placeholder).

---

## Data Model

```clarity
(define-map wallets { user: principal }
  { balance: uint, nonce: uint, last-activity: uint })
```

### Derived helpers

* `get-wallet-data(user)` → returns default `{balance: u0, nonce: u0, last-activity: u0}` when not found.
* `get-balance(user)`, `get-nonce(user)`, `get-last-activity(user)`.

**Design note:** Not persisting zero balances saves a write on account cleanup and prevents long-term storage bloat.

---

## Errors

* `ERR-UNAUTHORIZED (err u100)` – caller isn’t the contract owner for owner-only flows.
* `ERR-INSUFFICIENT-BALANCE (err u101)`
* `ERR-INVALID-AMOUNT (err u102)` – zero or invalid amounts, or sender==recipient for internal transfer.
* `ERR-TRANSFER-FAILED (err u103)` – reserved for STX transfer failures (not thrown in current code path).

---

## Public API

### `deposit(amount: uint) -> (response bool uint)`

* Validates `amount > 0`.
* **Writes once**: increments sender balance, updates `last-activity`.
* Performs `stx-transfer?` from sender → contract.
* **Returns** the result of `stx-transfer?`.

### `withdraw(amount: uint) -> (response bool uint)`

* Validates `amount > 0` and sufficient balance.
* If new balance is zero: `map-delete`; else `map-set` (increments nonce).
* `as-contract (stx-transfer? …)` from contract → sender.

### `batch-transfer(recipients: (list 10 {to: principal, amount: uint})) -> (response (list ...) uint)`

* Computes `total-amount` using `fold` over the list (via `get-transfer-amount`).
* Single debit from sender (delete or set based on new balance; increments nonce).
* Credits each recipient with one `map-set`.
* Returns `(ok (map process-single-transfer recipients))` (list of credited amounts).

**Gas note:** One sender write, N recipient writes; no per-recipient debits.

### `internal-transfer(to: principal, amount: uint) -> (response uint uint)`

* Validates `amount > 0`, `to != sender`, and sufficient sender balance.
* Updates sender (delete or set; increments nonce).
* Updates recipient with a single `map-set`.
* Returns `(ok amount)`.
  **No STX moves; pure ledger update ⇒ cheapest transfer path.**

### `emergency-pause() -> (response bool uint)`

* Owner-only guard present; **placeholder** to integrate with modifiers or flags gating state changes.

---

## Read-Only Endpoints

* `get-balance(user)` → `uint`
* `get-nonce(user)` → `uint`
* `get-last-activity(user)` → `uint` (block height)
* `get-contract-stats()` → `(ok { contract-balance: uint, block-height: uint })`
* `estimate-transfer-cost(amount)` → `(ok u1000)` (**placeholder**)

---

## Private Helpers

* `get-wallet-data(user)` – returns default structure when missing.
* `get-transfer-amount(transfer)` – extracts `amount` for folds.
* `process-single-transfer(transfer)` – credits recipient balance; returns the credited amount.
* `verify-signatures(message, signatures, signers)` – **placeholder** for efficient multi-sig verification.

---

## Typical Flows

1. **Deposit**

   * Call `deposit(uX)`.
   * Balance increases; `last-activity = block-height`.

2. **Withdraw**

   * Call `withdraw(uX)` with `X ≤ balance`.
   * Balance decreases; storage **deleted** if zero.

3. **Send multiple recipients**

   * Build up to 10 transfers: `(list {to: p1, amount: uA} {to: p2, amount: uB} ...)`.
   * Call `batch-transfer(list)`.
   * Sender debited once; recipients credited in a loop.

4. **Internal Transfer**

   * `internal-transfer(p-recipient, uX)`; cheapest path when both users are in-contract.

---

## Gas-Saving Techniques Used

* **Zero-balance pruning:** `map-delete` when balance hits `u0`.
* **Batched writes:** One `map-set` per actor per action.
* **Default reads:** `default-to` avoids dummy initializations.
* **Fold + map:** Calculations performed in memory before a single write.
* **Nonce co-located:** Replay/order tracking without a separate map.

---

## Security & Operational Notes

* **Contract custody:** Deposits move STX into the contract account; withdrawals use `as-contract` transfers. Keep `contract-balance` funded for withdrawals.
* **Replay/order:** Nonce increments on **state-changing debits** (withdraw/internal/batch). Deposits do **not** increment nonce.
* **Owner powers:** Only a placeholder `emergency-pause`. To actually pause, add a `var paused` flag and gate public functions with `asserts! (not (var-get paused))`.
* **Input validation:** Amounts must be `> u0`; internal transfers forbid `to == sender`.
* **Failure handling:** Current paths return `(ok ...)` after successful writes; if you later add error propagation for STX failures, ensure writes happen **after** transfer success or add compensating logic.

---

## Integration Examples

### Query a balance

```clarity
(contract-call? 'SP…/wallet get-balance tx-sender)
```

### Deposit 1000 uSTX

```clarity
;; Send STX with the transaction and call:
(contract-call? 'SP…/wallet deposit u1000)
```

### Withdraw 500 uSTX

```clarity
(contract-call? 'SP…/wallet withdraw u500)
```

### Internal transfer 250 uSTX

```clarity
(contract-call? 'SP…/wallet internal-transfer 'SP2… u250)
```

### Batch transfer

```clarity
(define-constant recipients
  (list {to: 'SP2…, amount: u100}
        {to: 'SP3…, amount: u200}))
(contract-call? 'SP…/wallet batch-transfer recipients)
```

---

## Testing Checklist

* Deposit → balance updated; `last-activity` equals current `block-height`.
* Withdraw exact full balance → entry deleted (`map-get?` is `none`).
* Internal transfer self → `ERR-INVALID-AMOUNT`.
* Batch transfer where `sum(amounts) == balance` → sender deleted.
* Batch transfer insufficient funds → `ERR-INSUFFICIENT-BALANCE`.
* Nonce increments only on debits (withdraw, internal, batch).
* Contract stats reflect on-chain `stx-get-balance`.
* Owner guard on `emergency-pause`.

---

## Extending the Contract

* **Pause switch:** `(define-data-var paused bool false)` + gate public functions.
* **Fees:** Deduct fixed/percentage fee on debits; credit to a treasury principal.
* **Events/logging:** Emit standard read-only mirrors or off-chain indexer hooks.
* **Multi-sig:** Implement `verify-signatures` and require threshold approvals on debits.
* **Allowances:** Add delegated internal transfers using nonces to prevent replay.

---

## Limitations

* `verify-signatures` and `estimate-transfer-cost` are placeholders.
* No native “token” abstraction—this ledger tracks STX only.
* No rate-limits or per-block caps; consider adding if needed.

---

## License

 MIT/Apache-2.0 .
